### PR TITLE
Feature: multi-replace false

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,7 @@ module.exports = function(grunt) {
 			},
 			test : {
 				options : {
+					multistr : true,		// allow unsafe line breaks (for test fixtures and whatnot)
 					'-W030' : true
 				},
 				src : [

--- a/src/maltypart.js
+++ b/src/maltypart.js
@@ -106,36 +106,51 @@
 		 *	@param {Boolean} [replace=true]		By default, any existing field with the same name is replaced. If `replace` is set to `false`, existing values will be left in-place, and the new value will be appended. This results in duplicate keys (which can be useful!).
 		 *	@returns {this}
 		 */
-		append : function(fields, replace) {
-			var name, i, pending, callback;
+		append : function(fields, replace, callback) {
+			var name, val, i, pending, cb;
 			if (typeof fields==='string' && arguments.length>=2) {
 				return this.setField.apply(this, arguments);
 			}
 
 			if (typeof replace==='function') {
-				pending = 1;
+				i = callback;
 				callback = replace;
-				replace = function() {
+				replace = i;
+			}
+
+			if (typeof callback==='function') {
+				pending = 1;
+				cb = function() {
 					if (!--pending) callback();
 				};
 			}
 
 			if (isArray(fields)) {
 				for (i=0; i<fields.length; i++) {
+					val = fields[i];
 					pending++;
-					this.setField(fields[i].name, fields[i].value, replace);
+					this.setField(val.name, val.value, replace!==false, null, cb);
 				}
 			}
 			else {
 				for (name in fields) {
 					if (fields.hasOwnProperty(name)) {
-						pending++;
-						this.setField(name, fields[name], replace);
+						val = fields[name];
+						if (isArray(val)) {
+							for (i=0; i<val.length; i++) {
+								pending++;
+								this.setField(name, val[i], replace===true, null, cb);
+							}
+						}
+						else {
+							pending++;
+							this.setField(name, val, replace!==false, null, cb);
+						}
 					}
 				}
 			}
 
-			if (pending) replace();
+			if (pending) cb();
 
 			return this;
 		},

--- a/test/spec/maltypart.js
+++ b/test/spec/maltypart.js
@@ -114,6 +114,79 @@ describe('maltypart', function() {
 				], callback);
 				expect(callback).to.have.been.calledTwice;
 			});
+
+			it('should append multiple fields with the same name', function() {
+				var body = new maltypart.RequestBody(),
+					callback = sinon.spy();
+
+				body.append({
+					foo: 'bar',
+					test: new maltypart.RequestField('<h1>hi</h1>', 'text/html'),
+					multiple: [
+						new maltypart.RequestField('<a>a</a>', 'text/html'),
+						new maltypart.RequestField('b', 'text/plain'),
+						new maltypart.RequestField('{"c":"c"}', 'text/json')
+					]
+				}, callback);
+
+				expect(callback).to.have.been.calledOnce;
+
+				expect(body.fields)
+					.to.have.property('test')
+					.that.is.an('object');
+
+				expect(body.fields)
+					.to.have.property('multiple')
+					.that.is.an('array')
+					.with.length(3);
+			});
+
+			it('should serialize complex example', function() {
+				var body = new maltypart.RequestBody(),
+					callback = sinon.spy();
+
+				body.append({
+					foo: 'bar',
+					test: new maltypart.RequestField('<h1>hi</h1>', 'text/html'),
+					multiple: [
+						new maltypart.RequestField('<a>a</a>', 'text/html'),
+						new maltypart.RequestField('b', 'text/plain'),
+						new maltypart.RequestField('{"c":"c"}', 'text/json')
+					]
+				});
+
+				var boundary = body.boundary;
+
+				var reference = '\
+--'+boundary+'\r\n\
+Content-Disposition: form-data; name="foo"\r\n\
+\r\n\
+bar\r\n\
+--'+boundary+'\r\n\
+Content-Disposition: form-data; name="test"\r\n\
+Content-type: text/html\r\n\
+\r\n\
+<h1>hi</h1>\r\n\
+--'+boundary+'\r\n\
+Content-Disposition: form-data; name="multiple"\r\n\
+Content-type: text/html\r\n\
+\r\n\
+<a>a</a>\r\n\
+--'+boundary+'\r\n\
+Content-Disposition: form-data; name="multiple"\r\n\
+Content-type: text/plain\r\n\
+\r\n\
+b\r\n\
+--'+boundary+'\r\n\
+Content-Disposition: form-data; name="multiple"\r\n\
+Content-type: text/json\r\n\
+\r\n\
+{"c":"c"}\r\n\
+--'+boundary+'--\r\n\
+';
+
+				expect(body.toString()).to.equal(reference);
+			});
 		});
 	});
 });


### PR DESCRIPTION
Adds support for duplicate keys when calling `.append()` with Arrays.

### Example:

```js
body.append({
    file: [
        new multipart.RequestField('foo', 'text/plain'),
        new multipart.RequestField('bar', 'text/plain')
    ]
});
```

This should now result in two multipart fields, each with `name=file`.